### PR TITLE
allow geojsonIdKey to be a string or number

### DIFF
--- a/src/components/ChoroplethLayer.vue
+++ b/src/components/ChoroplethLayer.vue
@@ -22,7 +22,7 @@ function mouseover({ target }) {
 
   let geojsonItem = target.feature.properties
   let item = this.geojsonData.data.find(
-    x => x[this.idKey] === Number(geojsonItem[this.geojsonIdKey])
+    x => x[this.idKey] === geojsonItem[this.geojsonIdKey]
   )
   let tempItem = { name: item[this.titleKey], value: item[this.value.key] }
   if (this.extraValues) {
@@ -76,7 +76,7 @@ export default {
       currentItem: { name: "", value: 0 },
       geojsonOptions: {
         style: feature => {
-          let itemGeoJSONID = Number(feature.properties[this.geojsonIdKey])
+          let itemGeoJSONID = feature.properties[this.geojsonIdKey]
           let color = "NONE"
           const {data} = this.geojsonData
           let item = data.find(x => x[this.idKey] === itemGeoJSONID)


### PR DESCRIPTION
Resolves https://github.com/voluntadpear/vue-choropleth/issues/13 :

> I'm having a problem colouring a map where the values for geojsonIdKey and the (data) idKey are strings (rather than integers).

> In src/components/ChoroplethLayer.vue the assumption there is an assumption that keys are numbers, and this appears deliberate. 