### PR TITLE
prevent error when data for geojson feature is missing

### DIFF
--- a/src/components/ChoroplethLayer.vue
+++ b/src/components/ChoroplethLayer.vue
@@ -24,6 +24,11 @@ function mouseover({ target }) {
   let item = this.geojsonData.data.find(
     x => x[this.idKey] === Number(geojsonItem[this.geojsonIdKey])
   )
+  if (!item) {
+    this.currentItem = { name: "", value: 0 }
+    return
+  }
+
   let tempItem = { name: item[this.titleKey], value: item[this.value.key] }
   if (this.extraValues) {
     let tempValues = []


### PR DESCRIPTION
if you have geojson features that are not part of your data object an
execption is raised. if no item can be found for a given feature, assume
no data is present.

The following line caused an error because `item` is undefined in this situation:

```js
let tempItem = { name: item[this.titleKey], value: item[this.value.key] }
```